### PR TITLE
MediaWikiRenderer.py: Remove \n from enumerate callback

### DIFF
--- a/texla/Renderers/MediaWikiRenderer.py
+++ b/texla/Renderers/MediaWikiRenderer.py
@@ -322,7 +322,7 @@ class MediaWikiRenderer(Renderer):
 
     def r_enumerate(self, block):
         self.list_level += '#'
-        s = ['\n']
+        s = []
         for item in block.ch_blocks:
             s.append(self.list_level)
             s.append(self.render_children_blocks(item).strip())


### PR DESCRIPTION
The \n between items of a list breaks the enumeration, so \n is removed.
Closes #T2802